### PR TITLE
Fix Http-get example

### DIFF
--- a/examples/http-get/Main.elm
+++ b/examples/http-get/Main.elm
@@ -6,7 +6,7 @@ import Html.Attributes exposing (value)
 import Html.Events exposing (onClick, onInput)
 import Html.App exposing (program)
 import Http exposing (get, Error)
-
+import Task
 
 main : Program Never
 main =
@@ -32,13 +32,12 @@ type alias Repo =
 type alias Model =
     { query : String
     , repos : List Repo
-    , error : Maybe String
     }
 
 
 init : ( Model, Cmd Msg )
 init =
-    ( Model "evancz" [] Nothing, Cmd.none )
+    ( Model "evancz" [], Cmd.none )
 
 
 decoder : Decoder (List Repo)
@@ -83,7 +82,12 @@ update msg model =
             ( { model | repos = repos }, Cmd.none )
 
         ResponseFail err ->
-            ( { model | error = err }, Cmd.none )
+            case err of
+                Http.UnexpectedPayload errorMessage ->
+                    Debug.log errorMessage
+                    ( model, Cmd.none )
+                _ ->
+                    ( model, Cmd.none )
 
 
 sendGet : (Error -> a) -> (b -> a) -> String -> Decoder b -> Cmd a

--- a/examples/http-get/README.md
+++ b/examples/http-get/README.md
@@ -6,6 +6,10 @@ to [List user repositories](https://developer.github.com/v3/repos/#list-user-rep
 ## Building the example
 
 ```sh
-$ elm-package istall -y
+$ elm-package install -y
 $ elm-make Main.elm
+
+or alternatively
+
+$ elm-reactor
 ```


### PR DESCRIPTION
Hi Halfzebra,

I had some problems running the Http-get example. 

The first was a missing Task import, which was easy enough to solve. 

The second related to a type signature issue with the update function. The Http.get function may return a Http.Error which didn't match up with what was being stored in the model. 

The quick hack was not to save the error in the app's model (besides, how should it be initialised?), which worked fine. However, I thought logging the error to the console would be a minor improvement on my hack.

Best regards,
Iain
