### PR TITLE
Problem: Broken link to 'Subscription batching'

### DIFF
--- a/examples/fractal-architecture/README.md
+++ b/examples/fractal-architecture/README.md
@@ -8,7 +8,7 @@ Features:
 - Module splitting
 - Usage of `Html.App.programWithFlags`
 - Module composition
-- [Subscription batching](examples/fractal-architecture/src/App/Subscriptions.elm) for subscribing to `Keyboard` messages from child modules
+- [Subscription batching](src/App/Subscriptions.elm) for subscribing to `Keyboard` messages from child modules
 
 ## Building the example
 


### PR DESCRIPTION
The relative path was incorrect.

Solution: Remove the redundant `examples/fractal-architecture/` part of the relative URL.